### PR TITLE
Changed code for getting parser class name.

### DIFF
--- a/lib/peddler/request.rb
+++ b/lib/peddler/request.rb
@@ -39,7 +39,7 @@ module Peddler
     private
 
     def parser
-      @parser ||= Object.const_get(self.class.name.sub('Request', 'Parser'))
+      @parser ||= self.class.name.sub('Request', 'Parser').split('::').inject(Object) { |mod, klass| mod.const_get(klass) }
     end
 
     def fetch(&blk)


### PR DESCRIPTION
Peddler wasn't working for me under ruby 1.9.3 with rails 3.2. After some research I found an alternative to getting the parser class from the request which does work.
