### PR TITLE
Allow per-client path setting

### DIFF
--- a/lib/peddler/client.rb
+++ b/lib/peddler/client.rb
@@ -22,6 +22,7 @@ module Peddler
       'ATVPDKIKX0DER'  => 'mws.amazonservices.com'
     }
 
+    attr_accessor :path
     attr_writer :merchant_id, :marketplace_id
     attr_reader :body
 
@@ -42,7 +43,7 @@ module Peddler
     end
 
     def aws_endpoint
-      "https://#{host}#{self.class.path}"
+      "https://#{host}#{self.path || self.class.path}"
     end
 
     def marketplace_id

--- a/test/unit/peddler/test_client.rb
+++ b/test/unit/peddler/test_client.rb
@@ -33,6 +33,13 @@ class PeddlerClientTest < MiniTest::Test
     assert @client.aws_endpoint.match(%r{/Foo$})
   end
 
+  def test_instance_path_overrides_class_path
+    @klass.path('/Foo')
+
+    @client.path = '/Foo/Bar'
+    assert @client.aws_endpoint.match(%r{/Foo/Bar$})
+  end
+
   def test_default_path
     assert_equal '/', @klass.path
   end


### PR DESCRIPTION
We're implementing Off-Amazon Payments and I hit a roadblock when trying to use the AWS Sandbox. The production API endpoint is "/OffAmazonPayments/2013-01-01/" which is fine and well, but the sandbox endpoint is "/OffAmazonPayments_Sandbox/2013-01-01/" which, unless I'm mistaken, is not touchable in the current Peddler implementation.

This allows setting the path as an instance variable that can override the class variable. So the big win is that you can pass in this path when instantiating a client. So for instance, when hitting the Sandbox:

```
MWS.off_amazon_payments(
  path: '/OffAmazonPayments_Sandbox/2013-01-01/',
  marketplace_id: 'hello',
  merchant_id: 'derp',
  aws_access_key_id: 'herp',
  aws_secret_access_key: 'blah'
)
```
