### PR TITLE
add version to the query

### DIFF
--- a/lib/mws/cart_information/client.rb
+++ b/lib/mws/cart_information/client.rb
@@ -16,7 +16,8 @@ module MWS
     # @note In addition to registering for Amazon MWS, you must also request
     #   authorization to use the Cart Information API section.
     class Client < ::Peddler::Client
-      path '/CartInformation/2014-03-01'
+      version "2014-03-01"
+      path "/CartInformation/#{version}"
 
       # Lists shopping carts
       #

--- a/lib/mws/customer_information/client.rb
+++ b/lib/mws/customer_information/client.rb
@@ -18,7 +18,8 @@ module MWS
     # @note In addition to registering for Amazon MWS, you must request
     #   authorization to use the Customer Information API.
     class Client < ::Peddler::Client
-      path '/CustomerInformation/2014-03-01'
+      version "2014-03-01"
+      path "/CustomerInformation/#{version}"
 
       # Lists customer accounts based on search criteria that you specify
       #

--- a/lib/mws/fulfillment_inbound_shipment/client.rb
+++ b/lib/mws/fulfillment_inbound_shipment/client.rb
@@ -7,7 +7,8 @@ module MWS
     # also request lists of inbound shipments or inbound shipment items based on
     # criteria that you specify.
     class Client < ::Peddler::Client
-      path '/FulfillmentInboundShipment/2010-10-01'
+      version "2010-10-01"
+      path "/FulfillmentInboundShipment/#{version}"
 
       # Returns the information required to create an inbound shipment
       #

--- a/lib/mws/fulfillment_inventory/client.rb
+++ b/lib/mws/fulfillment_inventory/client.rb
@@ -9,7 +9,8 @@ module MWS
     # selling your inventory on Amazon's retail web site or through other retail
     # channels.
     class Client < ::Peddler::Client
-      path '/FulfillmentInventory/2010-10-01'
+      version "2010-10-01"
+      path "/FulfillmentInventory/#{version}"
 
       # Returns information about the availability of a seller's inventory
       #

--- a/lib/mws/fulfillment_outbound_shipment/client.rb
+++ b/lib/mws/fulfillment_outbound_shipment/client.rb
@@ -13,7 +13,8 @@ module MWS
     # on when they were fulfilled and by the fulfillment method associated with
     # them.
     class Client < ::Peddler::Client
-      path '/FulfillmentOutboundShipment/2010-10-01'
+      version "2010-10-01"
+      path "/FulfillmentOutboundShipment/#{version}"
 
       # Lists fulfillment order previews
       #

--- a/lib/mws/off_amazon_payments/client.rb
+++ b/lib/mws/off_amazon_payments/client.rb
@@ -14,14 +14,15 @@ module MWS
     #   Payments. You cannot use this API section to process payments for Amazon
     #   Marketplace, Amazon Webstore, or Checkout by Amazon.
     class Client < ::Peddler::Client
-      path '/OffAmazonPayments/2013-01-01/'
+      version "2013-01-01"
+      path "/OffAmazonPayments/#{version}/"
 
       # Switches the client to the sandbox environment
       #
       # @see https://payments.amazon.com/help/Checkout-by-Amazon/Using-the-Checkout-by-Amazon-Sandbox/Overview-of-the-Sandbox
       # @return [self]
       def sandbox
-        self.path = '/OffAmazonPayments_Sandbox/2013-01-01/'
+        self.path = "/OffAmazonPayments_Sandbox/#{version}/"
         self
       end
 

--- a/lib/mws/orders/client.rb
+++ b/lib/mws/orders/client.rb
@@ -5,7 +5,8 @@ module MWS
     # With the MWS Orders API, you can list orders created or updated during a
     # time frame you specify or retrieve information about specific orders.
     class Client < ::Peddler::Client
-      path '/Orders/2013-09-01'
+      version "2013-09-01"
+      path "/Orders/#{version}"
 
       # Lists orders
       #

--- a/lib/mws/products/client.rb
+++ b/lib/mws/products/client.rb
@@ -7,7 +7,8 @@ module MWS
     # sourcing and pricing decisions for listing those products on Amazon
     # Marketplace websites.
     class Client < ::Peddler::Client
-      path '/Products/2011-10-01'
+      version "2011-10-01"
+      path "/Products/#{version}"
 
       # Lists products and their attributes, based on a search query
       #

--- a/lib/mws/recommendations/client.rb
+++ b/lib/mws/recommendations/client.rb
@@ -7,7 +7,8 @@ module MWS
     # is an actionable, timely, and personalized opportunity to increase your
     # sales and performance.
     class Client < ::Peddler::Client
-      path '/Recommendations/2013-04-01'
+      version "2013-04-01"
+      path "/Recommendations/#{version}"
 
       # Checks whether there are active recommendations for each category for
       # the given marketplace, and if there are, returns the time when

--- a/lib/mws/sellers/client.rb
+++ b/lib/mws/sellers/client.rb
@@ -5,7 +5,8 @@ module MWS
     # The Sellers API lets sellers retrieve information about their seller
     # account, such as the marketplaces they participate in.
     class Client < ::Peddler::Client
-      path '/Sellers/2011-07-01'
+      version "2011-07-01"
+      path "/Sellers/#{version}"
 
       # Lists the marketplaces the seller participates in
       #

--- a/lib/mws/subscriptions/client.rb
+++ b/lib/mws/subscriptions/client.rb
@@ -9,7 +9,8 @@ module MWS
     # Amazon MWS service. Instead, the information is sent directly to you when
     # an event occurs to which you are subscribed.
     class Client < ::Peddler::Client
-      path '/Subscriptions/2013-07-01'
+      version "2013-07-01"
+      path "/Subscriptions/#{version}"
 
       # Registers a new destination to receive notifications
       #

--- a/lib/mws/webstore/client.rb
+++ b/lib/mws/webstore/client.rb
@@ -13,7 +13,8 @@ module MWS
     # that your Webstore tracks, can help you determine how many notifications
     # were converted into sales.
     class Client < ::Peddler::Client
-      path '/Webstore/2014-09-01/'
+      version "2014-09-01"
+      path "/Webstore/#{version}/"
 
       # Lists subscription counts of subscriptions in a specified state,
       # including the items that are subscribed to

--- a/lib/peddler/client.rb
+++ b/lib/peddler/client.rb
@@ -11,7 +11,7 @@ module Peddler
     include Jeff
 
     attr_accessor :auth_token
-    attr_writer :merchant_id, :marketplace_id, :path
+    attr_writer :merchant_id, :marketplace_id, :path, :version
     attr_reader :body
 
     alias_method :configure, :tap
@@ -36,6 +36,10 @@ module Peddler
 
       def path(path = nil)
         path ? @path = path : @path ||= '/'
+      end
+
+      def version(version = nil)
+        version ? @version = version : @version ||= ""
       end
 
       def on_error(&blk)
@@ -82,6 +86,10 @@ module Peddler
       @path ||= self.class.path
     end
 
+    def version
+      @version ||= self.class.version
+    end
+
     def body=(str)
       headers['Content-Type'] = content_type(str)
       @body = str
@@ -100,6 +108,7 @@ module Peddler
     end
 
     def run
+      operation.store('Version', version) unless version.to_s == ""
       opts = defaults.merge(query: operation, headers: headers)
       opts.store(:body, body) if body
       opts.store(:response_block, Proc.new) if block_given?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -58,7 +58,7 @@ VCR.configure do |c|
   # Ignore transient params when building VCR fixtures.
   matcher = VCR.request_matchers.uri_without_param(
     'AWSAccessKeyId', 'SellerId', 'Signature', 'Timestamp', 'StartDate',
-    'CreatedAfter', 'QueryStartDateTime'
+    'CreatedAfter', 'QueryStartDateTime', 'Version'
   )
 
   c.default_cassette_options = {


### PR DESCRIPTION
Even thought the url should already have the version, but today when i try to do some operation using the inbound shipment api, some action fail bc amazon use older version to handle the request. Therefore, add the version to the query to ensure they use the right version, which amazon scratch pad also have this in their query

Thankyou for your attention
