### PR TITLE
Remove space in lambda rocket syntax to support ruby 1.9

### DIFF
--- a/lib/peddler/client.rb
+++ b/lib/peddler/client.rb
@@ -73,7 +73,7 @@ module Peddler
       end
     end
 
-    @error_handler = -> (e) { fail e }
+    @error_handler = ->(e) { fail e }
 
     # Creates a new client instance
     #


### PR DESCRIPTION
The space is fine in ruby 2.0 but explodes in ruby 1.9. Weird, I know.

More here:
http://ruby-journal.com/becareful-with-space-in-lambda-hash-rocket-syntax-between-ruby-1-dot-9-and-2-dot-0/