### PR TITLE
allow xml parser to respond to XML with 'Message'

### DIFF
--- a/lib/peddler/xml_response_parser.rb
+++ b/lib/peddler/xml_response_parser.rb
@@ -11,6 +11,8 @@ module Peddler
 
     def find_data
       results = xml.values.first.find { |k, _| k.include?('Result') }
+      results = xml.values.first.find { |k, _| k == 'Message' } unless results
+
       results ? results.last : nil
     end
   end

--- a/lib/peddler/xml_response_parser.rb
+++ b/lib/peddler/xml_response_parser.rb
@@ -10,8 +10,8 @@ module Peddler
     private
 
     def find_data
-      results = xml.values.first.find { |k, _| k.include?('Result') }
-      results = xml.values.first.find { |k, _| k == 'Message' } unless results
+      results = xml.values.first.find { |k, _| k.include?('Result') } ||
+                xml.values.first.find { |k, _| k == 'Message' }
 
       results ? results.last : nil
     end

--- a/test/unit/peddler/test_xml_response_parser.rb
+++ b/test/unit/peddler/test_xml_response_parser.rb
@@ -5,16 +5,26 @@ class TestPeddlerXMLResponseParser < MiniTest::Test
   def setup
     body = '<Response><Result><NextToken>123</NextToken>'\
            '<Foo>Bar</Foo></Result></Response>'
-    res = OpenStruct.new(
+
+    @parser = Peddler::XMLResponseParser.new(response(body))
+  end
+
+  def response(body)
+    OpenStruct.new(
       body: body,
       headers: { 'Content-Type' => 'text/xml', 'Content-Length' => '78' }
     )
-
-    @parser = Peddler::XMLResponseParser.new(res)
   end
 
   def test_parses_data
     assert_equal 'Bar', @parser.parse['Foo']
+  end
+
+  def test_parses_message_data
+    body_with_message = '<Response><Message><NextToken>123</NextToken>'\
+           '<Foo>Bar</Foo></Message></Response>'
+    parser = Peddler::XMLResponseParser.new(response(body_with_message))
+    assert_equal 'Bar', parser.parse['Foo']
   end
 
   def test_next_token


### PR DESCRIPTION
XML response from get_feed_submission_result does not contain the string 'Result' and so calling parse on the response returns nil.  This patch allows XMLResponseParser to parse XML with a Message node.