### PR TITLE
Add support for creating RMAs

### DIFF
--- a/lib/mws/fulfillment_outbound_shipment/client.rb
+++ b/lib/mws/fulfillment_outbound_shipment/client.rb
@@ -193,6 +193,21 @@ module MWS
         run
       end
 
+      # Creates a fulfillment return.
+      #
+      # @see http://docs.developer.amazonservices.com/en_US/fba_outbound/FBAOutbound_CreateFulfillmentReturn.html
+      # @param [String] seller_fulfillment_order_id
+      # @param [Array] items
+      # @return [Peddler::XMLParser]
+      def create_fulfillment_return(seller_fulfillment_order_id, items)
+        operation('CreateFulfillmentReturn')
+          .add('SellerFulfillmentOrderId' => seller_fulfillment_order_id)
+          .add('Items' => items)
+          .structure!('Items', 'member')
+
+        run
+      end
+
       # Gets the operational status of the API
       #
       # @see http://docs.developer.amazonservices.com/en_US/fba_outbound/MWS_GetServiceStatus.html

--- a/lib/mws/fulfillment_outbound_shipment/client.rb
+++ b/lib/mws/fulfillment_outbound_shipment/client.rb
@@ -165,6 +165,34 @@ module MWS
         run
       end
 
+      # Returns a list of return reason codes for a seller SKU in a given marketplace.
+      #
+      # @see http://docs.developer.amazonservices.com/en_US/fba_outbound/FBAOutbound_ListReturnReasonCodes.html
+      # @param [String] seller_sku
+      # @param [Hash] opts
+      # @option opts [String] :marketplace_id
+      # @option opts [String] :seller_fulfillment_order_id
+      # @option opts [String] :language
+      # @return [Peddler::XMLParser]
+      def list_return_reason_codes(seller_sku, opts = {})
+        opts['MarketplaceId'] = opts.delete(:marketplace_id) if
+          opts.key?(:marketplace_id)
+        opts['SellerFulfillmentOrderId'] = opts.delete(:seller_fulfillment_order_id) if
+          opts.key?(:seller_fulfillment_order_id)
+        opts['Languagel'] = opts.delete(:language) if
+          opts.key?(:language)
+
+        operation('ListReturnReasonCodes')
+          .add(
+            opts.merge(
+              'SellerSKU' => seller_sku
+            )
+          )
+          .structure!('List', 'member')
+
+        run
+      end
+
       # Gets the operational status of the API
       #
       # @see http://docs.developer.amazonservices.com/en_US/fba_outbound/MWS_GetServiceStatus.html

--- a/test/unit/mws/test_fulfillment_outbound_shipment_client.rb
+++ b/test/unit/mws/test_fulfillment_outbound_shipment_client.rb
@@ -137,6 +137,21 @@ class TestMWSFulfillmentOutboundShipmentClient < MiniTest::Test
     assert_equal operation, @client.operation
   end
 
+  def test_lists_return_reason_codes
+    seller_sku = 'ABC123'
+
+    operation = {
+      'Action' => 'ListReturnReasonCodes',
+      'SellerSKU' => seller_sku
+    }
+
+    @client.stub(:run, nil) do
+      @client.list_return_reason_codes(seller_sku)
+    end
+
+    assert_equal operation, @client.operation
+  end
+
   def test_gets_service_status
     operation = {
       'Action' => 'GetServiceStatus'

--- a/test/unit/mws/test_fulfillment_outbound_shipment_client.rb
+++ b/test/unit/mws/test_fulfillment_outbound_shipment_client.rb
@@ -152,6 +152,32 @@ class TestMWSFulfillmentOutboundShipmentClient < MiniTest::Test
     assert_equal operation, @client.operation
   end
 
+  def test_creates_fulfillment_return
+    seller_fulfillment_order_id = 'ABC123'
+
+    item = { seller_return_item_id: 'ABC123',
+             seller_fulfillment_order_item_id: 'ABC123',
+             amazon_shipment_id: 'ABC123',
+             return_reason_code: 'VALID_RETURN_REASON_CODE',
+             return_comment: 'RETURN COMMENT FROM CLIENT' }
+
+    operation = {
+      'Action' => 'CreateFulfillmentReturn',
+      'SellerFulfillmentOrderId' => seller_fulfillment_order_id,
+      'Items.member.1.SellerReturnItemId' => item[:seller_return_item_id],
+      'Items.member.1.SellerFulfillmentOrderItemId' => item[:seller_fulfillment_order_item_id],
+      'Items.member.1.AmazonShipmentId' => item[:amazon_shipment_id],
+      'Items.member.1.ReturnReasonCode' => item[:return_reason_code],
+      'Items.member.1.ReturnComment' => item[:return_comment]
+    }
+
+    @client.stub(:run, nil) do
+      @client.create_fulfillment_return(seller_fulfillment_order_id, [item])
+    end
+
+    assert_equal operation, @client.operation
+  end
+
   def test_gets_service_status
     operation = {
       'Action' => 'GetServiceStatus'


### PR DESCRIPTION
Added a couple of operations first for validating return reasons (`ListReturnReasonCodes`) and creating fulfillment returns (`CreateFulfillmentReturn`). See issue #92.

Check the documentation for [Creating a fulfillment return](http://docs.developer.amazonservices.com/en_US/fba_guide/FBAGuide_CreateFulfillmentReturn.html)