### PR TITLE
"member" replaced by "PrepDetails"

### DIFF
--- a/lib/mws/fulfillment_inbound_shipment/client.rb
+++ b/lib/mws/fulfillment_inbound_shipment/client.rb
@@ -60,7 +60,7 @@ module MWS
                'InboundShipmentPlanRequestItems' =>
                  inbound_shipment_plan_request_items)
           .structure!('InboundShipmentPlanRequestItems', 'member')
-          .structure!('PrepDetailsList', 'member')
+          .structure!('PrepDetailsList', 'PrepDetails')
 
         run
       end

--- a/test/unit/mws/test_fulfillment_inbound_shipment_client.rb
+++ b/test/unit/mws/test_fulfillment_inbound_shipment_client.rb
@@ -45,16 +45,16 @@ class TestMWSFulfillmentInboundShipmentClient < MiniTest::Test
       'ShipFromAddress.CountryCode' => 'US',
       'InboundShipmentPlanRequestItems.member.1.SellerSKU' => 'SKU00001',
       'InboundShipmentPlanRequestItems.member.1.Quantity' => '1',
-      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.member.1.PrepInstruction' => 'Taping',
-      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.member.1.PrepOwner' => 'AMAZON',
-      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.member.2.PrepInstruction' => 'BubbleWrapping',
-      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.member.2.PrepOwner' => 'AMAZON',
+      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.1.PrepInstruction' => 'Taping',
+      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.1.PrepOwner' => 'AMAZON',
+      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.2.PrepInstruction' => 'BubbleWrapping',
+      'InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.2.PrepOwner' => 'AMAZON',
       'InboundShipmentPlanRequestItems.member.2.SellerSKU' => 'SKU00002',
       'InboundShipmentPlanRequestItems.member.2.Quantity' => '1',
-      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.member.1.PrepInstruction' => 'Taping',
-      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.member.1.PrepOwner' => 'AMAZON',
-      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.member.2.PrepInstruction' => 'BubbleWrapping',
-      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.member.2.PrepOwner' => 'AMAZON'
+      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.1.PrepInstruction' => 'Taping',
+      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.1.PrepOwner' => 'AMAZON',
+      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.2.PrepInstruction' => 'BubbleWrapping',
+      'InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.2.PrepOwner' => 'AMAZON'
     }
 
     @client.stub(:run, nil) do


### PR DESCRIPTION
In Amazon's MWS docs, it shows PrepDetailsList => PrepDetails => etc.

http://docs.developer.amazonservices.com/en_US/fba_inbound/FBAInbound_PreparationExamples.html

```
&InboundShipmentPlanRequestItems.member.1.SellerSKU=SKU00001
&InboundShipmentPlanRequestItems.member.1.Quantity=1
&InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.1.PrepInstruction=Taping          
&InboundShipmentPlanRequestItems.member.1.PrepDetailsList.PrepDetails.1.PrepOwner=AMAZON
&InboundShipmentPlanRequestItems.member.2.SellerSKU=SKU00002
&InboundShipmentPlanRequestItems.member.2.Quantity=1
&InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.1.PrepInstruction=Labeling         
&InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.1.PrepOwner=AMAZON
&InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.2.PrepInstruction=Taping         
&InboundShipmentPlanRequestItems.member.2.PrepDetailsList.PrepDetails.2.PrepOwner=SELLER
```