### PR TITLE
Use "member" structure for ShippingSpeedCategories

### DIFF
--- a/lib/mws/fulfillment_outbound_shipment/client.rb
+++ b/lib/mws/fulfillment_outbound_shipment/client.rb
@@ -32,7 +32,7 @@ module MWS
           .add(opts)
           .add('Address' => address, 'Items' => items)
           .structure!('Items', 'member')
-          .structure!('ShippingSpeedCategories')
+          .structure!('ShippingSpeedCategories', 'member')
 
         run
       end


### PR DESCRIPTION
It seems that the "ShippingSpeedCategories" option needs to be structured as a "member" list, like this:
```
&ShippingSpeedCategories.member.1=Expedited
&ShippingSpeedCategories.member.2=Standard
&ShippingSpeedCategories.member.3=Priority
```

...despite the fact that the Amazon documentation shows it like this:
```
&ShippingSpeedCategories.1=Expedited
&ShippingSpeedCategories.2=Standard
&ShippingSpeedCategories.3=Priority
```

Otherwise, I was getting this error:

```
Peddler::Errors::MalformedInput (Top level element may not be treated as a list)
```