### PR TITLE
Add InvalidRequestException to list of known error codes.

### DIFF
--- a/lib/peddler/errors/error.rb
+++ b/lib/peddler/errors/error.rb
@@ -15,6 +15,7 @@ module Peddler
       InvalidAccessKeyId
       InvalidAddress
       InvalidParameterValue
+      InvalidRequestException
       QuotaExceeded
       RequestThrottled
       SignatureDoesNotMatch


### PR DESCRIPTION
I think the Amazon documentation might be outdated since it is missing `InvalidRequestException` from its list of known error codes. I have seen this error in cases like this:

```xml
<ErrorResponse xmlns="http://mws.amazonaws.com/FulfillmentOutboundShipment/2010-10-01/">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidRequestException</Code>
    <Message>Value justatest for parameter Address.PostalCode is invalid. Reason: InvalidValue.</Message>
  </Error>
  <RequestId>ff6fee03-1bc1-455b-80ed-19e441b0f133</RequestId>
</ErrorResponse>
```

Since error classes are dynamically created, the constant that was being defined was `Peddler::Errors::InvalidRequestException`. However, I couldn't figure out why I couldn't rescue from that type of error and getting undefined constant errors. Turns out it was missing from this list.