### PR TITLE
Add United Arab Emirates to 1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.6.7] - 2018-03-02
 ### Added
 - Improve enabling new error handler.
 
@@ -137,7 +139,8 @@ to the Products client.
 
 ## 1.0.0 - 2015-08-25
 
-[Unreleased]: https://github.com/hakanensari/peddler/compare/v1.6.6...HEAD
+[Unreleased]: https://github.com/hakanensari/peddler/compare/v1.6.7...HEAD
+[1.6.7]: https://github.com/hakanensari/peddler/compare/v1.6.6...v1.6.7
 [1.6.6]: https://github.com/hakanensari/peddler/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/hakanensari/peddler/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/hakanensari/peddler/compare/v1.6.3...v1.6.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 ## Contributing
+
 In the spirit of [free software][free-sw], **everyone** is encouraged to help
 improve this project. Here are some ways *you* can contribute:
 
 [free-sw]: http://www.fsf.org/licensing/essays/free-sw.html
 
-* Use alpha, beta, and pre-release versions.
+* Use pre-release versions.
 * Report bugs.
 * Suggest new features.
 * Write or edit documentation.
@@ -12,12 +13,13 @@ improve this project. Here are some ways *you* can contribute:
 * Write code (**no patch is too small**: fix typos, add comments, clean up
   inconsistent whitespace).
 * Refactor code.
-* Fix [issues][].
+* [Fix issues.][issues]
 * Review patches.
 
 [issues]: https://github.com/hakanensari/peddler/issues
 
 ## Submitting an Issue
+
 We use the [GitHub issue tracker][issues] to track bugs and features. Before
 submitting a bug report or feature request, check to make sure it hasn't
 already been submitted. When submitting a bug report, please include a [Gist][]
@@ -25,7 +27,11 @@ that includes a stack trace and any details that may be necessary to reproduce
 the bug, including your gem version, Ruby version, and operating system.
 Ideally, a bug report should include a pull request with failing specs.
 
+Do not submit issues that are not specific to Peddler. If you have questions on how to use MWS, find help on [Amazon's seller forum][forum] or [Stack Overflow][so].
+
 [gist]: https://gist.github.com/
+[forum]: https://sellercentral.amazon.com/forums/c/amazon-marketplace-web-service-mws/
+[so]: https://stackoverflow.com/search?q=peddler+%5Bruby%5D+or+%5Bruby-on-rails%5D+or+%5Bamazon-mws%5D+answers%3A1..+score%3A0..
 
 ## Submitting a Pull Request
 1. [Fork the repository.][fork]

--- a/README.md
+++ b/README.md
@@ -87,9 +87,27 @@ MWS::Orders::Client.parser = MyParser
 
 For a sample implementation, see my [MWS Orders](https://github.com/hakanensari/mws-orders) library.
 
+### Throttling
+
+Amazon limits the number of requests you can submit to a given operation in a given amount of time.
+
+Peddler exposes header values showing the hourly quota of the current operation:
+
+```ruby
+res = client.some_method
+puts res.quota
+#<struct Quota max=200, remaining=150, resets_on=2017-01-01 00:12:00 UTC>
+```
+
+Read Amazon's tips on how to avoid throttling [here](https://docs.developer.amazonservices.com/en_US/dev_guide/DG_Throttling.html).
+
 ### Debugging
 
-To introspect requests, set the `EXCON_DEBUG` environment variable to a truthy value when making requests.
+If you are having trouble with a request, read [Amazon documentation](https://developer.amazonservices.com/gp/mws/docs.html). Peddler's source links individual operations to their corresponding entries in the Amazon docs.
+
+Note that some optional keywords have default values.
+
+To introspect requests, set the `EXCON_DEBUG` environment variable to `1` or similar truthy value. Peddler will then log request and response internals to stdout.
 
 ### Errors
 
@@ -112,6 +130,14 @@ rescue Excon::Error::ServiceUnavailable => e
   logger.warn e.response.message
   retry
 end
+```
+
+Peddler has an optional new error handler that raises more descriptive errors: for instance, `Peddler::Errors::RequestThrottled` instead of `Excon::Error::ServiceUnavailable`. This error handler will become the default in the next major version.
+
+To start using this now:
+
+```ruby
+require 'peddler/errors'
 ```
 
 ## The APIs

--- a/lib/peddler/marketplace.rb
+++ b/lib/peddler/marketplace.rb
@@ -40,6 +40,7 @@ module Peddler
       ['A1AM78C64UM0Y8', 'MX', 'mws.amazonservices.com'],
       ['ATVPDKIKX0DER', 'US', 'mws.amazonservices.com'],
       ['A2Q3Y263D00KWC', 'BR', 'mws.amazonservices.com'],
+      ['A2VIGQ35RCS4UG', 'AE', 'mws.amazonservices.ae'],
       ['A1PA6795UKMFR9', 'DE', 'mws-eu.amazonservices.com'],
       ['A1RKKUPIHCS9HS', 'ES', 'mws-eu.amazonservices.com'],
       ['A13V1IB3VIYZZH', 'FR', 'mws-eu.amazonservices.com'],

--- a/lib/peddler/version.rb
+++ b/lib/peddler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Peddler
-  VERSION = '1.6.6'
+  VERSION = '1.6.7'
 end


### PR DESCRIPTION
We are on the 1.6 release cycle of Peddler currently, and need to add UAE support. It's the same code change that was done for the endpoint in the 2 branch. I branched from 1.6.7, which I'm not sure is in master.

That is why I believe there are more changes I didn't make in the merge instead of just one line in `lib/peddler/marketplace.rb`.

Let me know if there is anything else I can do.