### PR TITLE
Documentation crawler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
         AWS_ACCESS_KEY_ID: secret
         AWS_SECRET_ACCESS_KEY: secret
 
+    - name: Check documentation links
+      run: ruby ./scripts/documentation_crawler.rb
+
     - name: Report
       continue-on-error: true
       if: success() && matrix.ruby == '2.6.x'

--- a/lib/mws/orders/client.rb
+++ b/lib/mws/orders/client.rb
@@ -15,7 +15,7 @@ module MWS
       # @note When calling this operation, you must specify a time frame using
       #   either created_after or last_updated_after. When requesting orders by
       #   "Unshipped" status you must also request "PartiallyShipped" orders.
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/Orders_ListOrders.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_ListOrders.html
       # @overload list_orders(*marketplace_id, opts = {})
       #   @param [Array<String>] marketplace_id
       #   @param [Hash] opts
@@ -53,7 +53,7 @@ module MWS
 
       # Lists the next page of orders
       #
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/Orders_ListOrdersByNextToken.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_ListOrdersByNextToken.html
       # @param [String] next_token
       # @return [Peddler::XMLParser]
       def list_orders_by_next_token(next_token)
@@ -65,7 +65,7 @@ module MWS
 
       # Gets one or more orders
       #
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/Orders_GetOrder.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_GetOrder.html
       # @param [Array<String>] amazon_order_ids
       # @return [Peddler::XMLParser]
       def get_order(*amazon_order_ids)
@@ -78,7 +78,7 @@ module MWS
 
       # Lists order items for an order
       #
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/Orders_ListOrderItems.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_ListOrderItems.html
       # @param [String] amazon_order_id
       # @return [Peddler::XMLParser]
       def list_order_items(amazon_order_id)
@@ -90,7 +90,7 @@ module MWS
 
       # Lists the next page of order items for an order
       #
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/Orders_ListOrderItemsByNextToken.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_ListOrderItemsByNextToken.html
       # @param [String] next_token
       # @return [Peddler::XMLParser]
       def list_order_items_by_next_token(next_token)
@@ -102,7 +102,7 @@ module MWS
 
       # Gets the service status of the API
       #
-      # @see https://docs.developer.amazonservices.com/en_US/orders/2013-09-01/MWS_GetServiceStatus.html
+      # @see https://docs.developer.amazonservices.com/en_US/orders-2013-09-01/MWS_GetServiceStatus.html
       # @return [Peddler::XMLParser]
       def get_service_status
         operation('GetServiceStatus')

--- a/scripts/documentation_crawler.rb
+++ b/scripts/documentation_crawler.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'net/http'
+require 'logger'
+
+logger = Logger.new(STDOUT)
+
+search_command = 'grep -R @see ./lib'
+output, = Open3.capture3(search_command)
+matches = output.split("\n")
+
+failed = false
+
+matches.each do |line|
+  url = line.match(/http.*/)[0]
+  logger.info "Fetching #{url} ..."
+
+  response = Net::HTTP.get_response(URI(url))
+
+  case response
+  when Net::HTTPSuccess, Net::HTTPRedirection
+    logger.info 'Success.'
+  else
+    failed = true
+    logger.error 'Failed.'
+  end
+end
+
+if failed
+  logger.warn 'Please fix broken documentation links.'
+  exit 1
+end


### PR DESCRIPTION
#### Changes
1. Adds an extra build step which `grep`s the codebase for `@see` tags, pings the respective links and exits with a failure unless all pings return successfully.
2. Fixes broken links. Here's an [example of a failing build](https://github.com/janklimo/peddler/runs/347659595) before I corrected the links.

@hakanensari curious to hear your thoughts 👍 

Closes #141 