### PR TITLE
docs: add evaluation of openapi3_parser for generator

### DIFF
--- a/extras/evaluations/openapi3-parser-2025-10-21.md
+++ b/extras/evaluations/openapi3-parser-2025-10-21.md
@@ -1,0 +1,487 @@
+# Evaluation: Using openapi3_parser for Peddler Generator
+
+Date: 2025-10-21
+Evaluator: Claude Code
+
+## Executive Summary
+
+This evaluation assesses the feasibility of replacing Peddler's current custom OpenAPI parsing (Swagger 2.0 + JSON.parse) with the `kevindew/openapi3_parser` gem. The switch would require converting Amazon's Swagger 2.0 specs to OpenAPI 3.0 using `swagger2openapi`.
+
+**Recommendation:** ⚠️ **PROCEED WITH CAUTION**
+
+While technically feasible, the switch introduces significant complexity and trade-offs that may not justify the benefits for this use case.
+
+## Current Approach
+
+**Tech Stack:**
+- Swagger 2.0 specs from Amazon
+- `JSON.parse` for loading specs
+- Custom parsers in `lib/generator/parsers/`
+- Custom resolvers in `lib/generator/resolvers/`
+- Manual `$ref` resolution via `TypeResolver`
+- Manual `allOf` merging in `Type#merge_from_all_of`
+
+**Lines of Custom Code:**
+- `parsers/path.rb`: ~47 lines
+- `resolvers/type_resolver.rb`: ~220 lines
+- `builders/type.rb`: ~362 lines
+- Total parsing logic: ~630 lines
+
+## Proposed Approach
+
+**Tech Stack:**
+- Convert Swagger 2.0 → OpenAPI 3.0 (swagger2openapi)
+- Parse with openapi3_parser gem
+- Automatic `$ref` resolution
+- Semi-automatic `allOf` handling (still needs iteration)
+
+## Key Findings
+
+### 1. Conversion Success Rate
+
+Tested 10 Amazon specs:
+- **Success:** 8/10 (80%)
+- **Failed:** 2/10 (20%)
+  - `customerFeedback_2024-06-01.json` - Malformed spec (fixable with `--patch` flag)
+  - `easyShip_2022-03-23.json` - Parser error
+
+**Finding:** Most specs convert successfully, but malformed specs require special handling.
+
+### 2. $ref Resolution
+
+**Current:**
+```ruby
+# Manual resolution in TypeResolver
+def resolve_ref_type(ref, for_comment, for_rbs = false)
+  ref_name = ref.split("/").last
+  # ... 15 more lines of logic
+end
+```
+
+**With openapi3_parser:**
+```ruby
+# Automatic resolution
+schema.properties.each do |prop_name, prop_schema|
+  # $refs are already resolved
+  type = prop_schema.type  # Just works!
+end
+```
+
+**Benefit:** Eliminates ~100 lines of complex $ref resolution logic.
+
+### 3. allOf Handling
+
+**Current:**
+```ruby
+# Type#merge_from_all_of manually merges properties
+definition["allOf"].each do |schema|
+  if schema["$ref"]
+    ref_def = specification.dig("definitions", ref_name)
+    # ... manual merging logic
+  end
+end
+```
+
+**With openapi3_parser:**
+```ruby
+# Still requires manual iteration, but $refs are resolved
+schema.all_of.each do |item|
+  # item.properties already resolved!
+  all_props.concat(item.properties.keys)
+end
+```
+
+**Benefit:** Simpler, but not eliminated. Still need to aggregate properties from `all_of` array.
+
+### 4. Validation
+
+**Current:** No built-in validation
+
+**With openapi3_parser:**
+```ruby
+document = Openapi3Parser.load_file(spec_file)
+if document.valid?
+  # proceed
+else
+  puts document.errors  # Detailed validation errors
+end
+```
+
+**Benefit:** Catches malformed specs early in development.
+
+### 5. Performance Impact
+
+Tested with 50 iterations of catalog-items spec:
+
+| Metric | Current (JSON) | New (openapi3_parser) | Overhead |
+|--------|----------------|----------------------|----------|
+| Parsing | 66.84ms | 169.03ms | +153% |
+| Conversion (one-time) | N/A | 187.99ms | N/A |
+
+**Finding:** Significant parsing overhead, but conversion is one-time cost that could be done during `bundle exec rake generate` setup.
+
+### 6. API Differences
+
+**Accessing Paths:**
+
+Current:
+```ruby
+model["paths"].each do |path, methods|
+  methods.select { |k, _| %w[get post].include?(k) }.each do |method, operation|
+    operation["operationId"]
+  end
+end
+```
+
+New:
+```ruby
+document.paths.each do |path, path_item|
+  %w[get post].each do |method|
+    operation = path_item.send(method)
+    operation.operation_id if operation
+  end
+end
+```
+
+**Accessing Schemas:**
+
+Current:
+```ruby
+spec["definitions"].each do |name, definition|
+  definition["properties"]
+end
+```
+
+New:
+```ruby
+document.components.schemas.each do |name, schema|
+  schema.properties
+end
+```
+
+**Finding:** Different API requires updating all generator code.
+
+## Pros and Cons
+
+### ✅ Pros
+
+1. **Automatic $ref Resolution**
+   - Eliminates ~100 lines of complex resolution logic
+   - Reduces chances of resolution bugs
+   - Cleaner, more maintainable code
+
+2. **Built-in Validation**
+   - Catches malformed specs during development
+   - Better error messages than custom parser
+   - Helps identify issues in Amazon's specs
+
+3. **Type Safety**
+   - Object-oriented API vs hash access
+   - Better IDE autocomplete support
+   - Harder to make typos (e.g., `schema.properties` vs `spec["properteis"]`)
+
+4. **Industry Standard**
+   - OpenAPI 3.0 is the current standard (Swagger 2.0 is deprecated)
+   - More tooling and ecosystem support
+   - Future-proof as more specs migrate to OAS3
+
+5. **Simplified TypeResolver**
+   - Current: 220 lines
+   - Estimated after: ~100 lines (50% reduction)
+
+### ❌ Cons
+
+1. **Conversion Step Required**
+   - All 100+ Amazon specs need conversion
+   - Adds ~188ms per spec (one-time cost)
+   - Need to handle conversion errors
+   - Requires Node.js dependency (swagger2openapi)
+
+2. **Performance Overhead**
+   - 153% slower parsing vs JSON.parse
+   - Matters during development when running generator repeatedly
+   - Could be mitigated by caching converted specs
+
+3. **allOf Not Fully Automatic**
+   - Still need to iterate `schema.all_of` and aggregate properties
+   - Similar complexity to current `merge_from_all_of`
+   - Expected "auto-merge" doesn't happen
+
+4. **Migration Effort**
+   - Update all generator code to use new API
+   - Rewrite tests to match new approach
+   - Risk of introducing bugs during migration
+   - Estimated: 2-3 days of work
+
+5. **Additional Dependency**
+   - Ruby: `openapi3_parser` gem
+   - Node: `swagger2openapi` (for conversion)
+   - More dependencies = more potential breakage
+
+6. **Malformed Specs**
+   - Some Amazon specs fail conversion
+   - Need special handling (`--patch` flag)
+   - Could break generator for certain APIs
+
+7. **Loss of Direct Control**
+   - Custom parser gives full control over behavior
+   - openapi3_parser might have bugs or limitations
+   - Harder to debug third-party code
+
+## Implementation Challenges
+
+### Challenge 1: Conversion Pipeline
+
+Need to decide when/where to convert specs:
+
+**Option A: Convert During Generation**
+```ruby
+def generate
+  Specs.sync  # Clone Amazon specs
+  Specs.convert_to_oas3  # New step: convert all specs
+  API.generate  # Use converted specs
+end
+```
+
+Pros: Always fresh
+Cons: Slow, requires Node.js at runtime
+
+**Option B: Pre-convert and Commit**
+```ruby
+# One-time conversion, commit OAS3 specs to repo
+selling-partner-api-models-oas3/
+```
+
+Pros: Fast, no Node.js dependency at runtime
+Cons: Large files in repo, sync issues
+
+**Option C: Lazy Conversion with Caching**
+```ruby
+# Convert on-demand, cache results
+def load_spec(file)
+  cache_file = convert_to_oas3_cached(file)
+  Openapi3Parser.load_file(cache_file)
+end
+```
+
+Pros: Fast after first run, no committed files
+Cons: Complex cache invalidation
+
+### Challenge 2: allOf Still Requires Custom Logic
+
+Expected:
+```ruby
+schema.properties  # Auto-merged from allOf
+```
+
+Reality:
+```ruby
+# Still need custom aggregation
+all_props = {}
+schema.all_of.each do |item|
+  all_props.merge!(item.properties) if item.properties
+end
+```
+
+This was a major expected benefit, but it's not as automatic as hoped.
+
+### Challenge 3: Handling Malformed Specs
+
+Some Amazon specs are malformed:
+```
+customerFeedback_2024-06-01.json: collectionFormat is only applicable to array
+```
+
+Need error handling:
+```ruby
+begin
+  system("swagger2openapi --patch --outfile #{out} #{input}")
+rescue
+  # Fallback? Skip? Warn?
+end
+```
+
+## Code Complexity Comparison
+
+### Current Generator Complexity
+
+**TypeResolver:** 220 lines
+- Manual $ref resolution: ~60 lines
+- allOf handling: ~40 lines
+- Type mapping: ~100 lines
+- Other: ~20 lines
+
+**Type Builder:** 362 lines
+- allOf merging: ~50 lines
+- Property sorting: ~30 lines
+- Dependency tracking: ~100 lines
+- Other: ~182 lines
+
+**Total Custom Parsing:** ~630 lines
+
+### Estimated New Complexity
+
+**TypeResolver:** ~100 lines (50% reduction)
+- ~~Manual $ref resolution~~ (eliminated)
+- allOf handling: ~30 lines (simpler but not eliminated)
+- Type mapping: ~50 lines (simpler with object API)
+- Other: ~20 lines
+
+**Type Builder:** ~300 lines (17% reduction)
+- allOf aggregation: ~30 lines (simpler)
+- Property sorting: ~30 lines (same)
+- Dependency tracking: ~60 lines (simpler, $refs resolved)
+- Other: ~180 lines
+
+**Conversion Logic:** ~50 lines (new)
+
+**Total:** ~450 lines
+
+**Net Reduction:** 180 lines (29%)
+
+## Alternative: Improve Current Parser
+
+Instead of switching, could improve current parser:
+
+1. **Add Validation**
+   ```ruby
+   # Use JSON Schema validator on Swagger 2.0 specs
+   gem 'json-schema'
+   ```
+
+2. **Refactor TypeResolver**
+   - Extract $ref resolution to separate class
+   - Add caching for resolved types
+   - Better error messages
+
+3. **Document Quirks**
+   - Add comments explaining allOf handling
+   - Document Amazon-specific workarounds
+
+**Estimated Effort:** 1 day vs 2-3 days for migration
+
+## Recommendations
+
+### 🔴 DO NOT SWITCH if:
+
+1. You value **stability** over modernization
+2. You want to **minimize dependencies**
+3. You need **maximum performance** during development
+4. The current parser works reliably (no known bugs)
+5. You have limited time for migration testing
+
+### 🟢 DO SWITCH if:
+
+1. You're experiencing **$ref resolution bugs**
+2. You want **better validation** of Amazon's specs
+3. You're willing to invest 2-3 days in migration
+4. You value **industry standards** (OAS3 > Swagger 2)
+5. You plan to add more generator features (ROI on cleaner code)
+
+### 🟡 HYBRID APPROACH:
+
+**Start with proof-of-concept for ONE API:**
+
+1. Pick a complex API (e.g., product-pricing with allOf)
+2. Convert and generate with openapi3_parser
+3. Compare generated code line-by-line
+4. If identical → continue with more APIs
+5. If different → investigate and decide
+
+**Benefits:**
+- Low risk (can revert easily)
+- Real-world validation
+- Clear success criteria (generated code unchanged)
+
+## Success Criteria
+
+If you proceed, consider the switch successful when:
+
+1. ✅ **Generated code is identical** (or changes are intentional improvements)
+2. ✅ **All tests pass** without modification
+3. ✅ **Generation time < 2x current** (acceptable overhead)
+4. ✅ **All Amazon specs convert** (or failures are documented/handled)
+5. ✅ **Code is more maintainable** (subjective but important)
+
+## Next Steps
+
+If moving forward:
+
+1. **Create feature branch** (`feature/openapi3-parser`)
+2. **Pick pilot API** (suggest: catalog-items or product-pricing)
+3. **Implement conversion** (cache in tmp/ directory)
+4. **Update generator** for pilot API only
+5. **Run diff** on generated code
+6. **Run tests** for pilot API
+7. **Evaluate results** against success criteria
+8. **Decide:** Continue to all APIs or revert
+
+**Estimated Timeline:**
+- Day 1: Setup conversion, update generator for pilot
+- Day 2: Fix issues, compare output
+- Day 3: Expand to more APIs if successful
+- Day 4: Testing and documentation
+
+## Conclusion
+
+Using `openapi3_parser` is **technically feasible** but introduces **significant trade-offs**:
+
+- **Pros:** Cleaner code, better validation, industry standard
+- **Cons:** More dependencies, slower parsing, migration effort
+
+The **29% code reduction** is modest compared to the **migration risk** and **performance impact**.
+
+**Final Recommendation:**
+
+Unless you're experiencing specific pain points with the current parser (like $ref bugs or allOf edge cases), the **cost of migration outweighs the benefits**. The current parser is "janky" but it **works reliably** for Amazon's specs.
+
+However, if you do switch:
+1. Use the **hybrid approach** (pilot one API first)
+2. Implement **cached conversion** (don't convert on every run)
+3. Set up **diff testing** (ensure generated code is identical)
+4. Budget **3-4 days** for full migration
+
+The evaluation proves it's **possible**, but **not necessarily advisable** given the marginal benefits vs migration cost.
+
+---
+
+## Appendix: Test Results
+
+### Conversion Test (10 specs)
+
+| Spec | Status | Paths | Schemas | Notes |
+|------|--------|-------|---------|-------|
+| awd_2024-05-09 | ✅ OK | 10 | 50 | |
+| aplusContent_2020-11-01 | ✅ OK | 7 | 79 | |
+| appIntegrations-2024-04-01 | ✅ OK | 3 | 7 | |
+| application_2023-11-30 | ✅ OK | 1 | 2 | |
+| catalogItemsV0 | ✅ OK | 1 | 5 | |
+| catalogItems_2020-12-01 | ✅ OK | 2 | 27 | |
+| catalogItems_2022-04-01 | ✅ OK | 2 | 40 | |
+| customerFeedback_2024-06-01 | ❌ FAIL | - | - | Needs --patch flag |
+| dataKiosk_2023-11-15 | ✅ OK | 3 | 8 | |
+| easyShip_2022-03-23 | ❌ ERROR | - | - | Parser validation errors |
+
+**Success Rate:** 80% (8/10)
+
+### Performance Benchmark
+
+- **JSON.parse:** 1.34ms per spec (avg)
+- **openapi3_parser:** 3.38ms per spec (avg)
+- **Overhead:** 2.5x slower
+- **swagger2openapi conversion:** 188ms per spec (one-time)
+
+### Code Samples
+
+All test scripts available in `/tmp/peddler-eval/`:
+- `test_parser.rb` - Basic parser demonstration
+- `compare_parsers.rb` - Side-by-side comparison
+- `test_allof.rb` - allOf handling test
+- `debug_allof.rb` - Deep dive into allOf API
+- `bulk_test.rb` - Batch conversion test
+
+---
+
+**Questions or Concerns?**
+
+This evaluation is comprehensive but based on limited testing. Additional edge cases may emerge with all 100+ Amazon specs.


### PR DESCRIPTION
Comprehensive evaluation of replacing current Swagger 2.0 + JSON parsing with openapi3_parser + swagger2openapi conversion.

Key findings:
- Technically feasible (80% conversion success rate)
- 29% code reduction (~630 to ~450 lines)
- 153% parsing overhead (performance impact)
- allOf not fully automatic (disappointing)
- Estimated 2-3 days migration effort

Recommendation: Not advisable unless experiencing specific pain points. Current parser works reliably despite being "janky."

Full analysis includes:
- Conversion testing (10 specs)
- Performance benchmarks
- API comparisons
- Implementation challenges
- Success criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)