### PR TITLE
Reduce false positives in link verification

### DIFF
--- a/bin/verify-links
+++ b/bin/verify-links
@@ -54,10 +54,17 @@ check_url() {
         ;;
       5*)
         if ((i < max_retries)); then
-          sleep $retry_delay
+          sleep $((retry_delay * i))
         else
-          touch "$tmpdir/failed"
-          log_error "$response $url (after $max_retries retries)"
+          log_warn "$response $url (after $max_retries retries)"
+        fi
+        ;;
+      0)
+        # Connection timeout or network error
+        if ((i < max_retries)); then
+          sleep $((retry_delay * i))
+        else
+          log_warn "$response $url (after $max_retries retries)"
         fi
         ;;
       *)

--- a/bin/verify-links
+++ b/bin/verify-links
@@ -48,7 +48,7 @@ check_url() {
         log_info "$response $url"
         return
         ;;
-      301|302)
+      301|302|429)
         log_warn "$response $url"
         return
         ;;


### PR DESCRIPTION
## Summary

- Treat HTTP 429 (rate limit) as a warning instead of a failure
- Treat 5xx errors and connection timeouts as warnings after retries — these are transient server issues (e.g. GitHub 502s), not broken links
- Add exponential backoff to retries (2s, 4s, 6s) instead of flat 2s delay
- Only fail the CI job on true client errors (4xx except 429)

## Test plan

- [ ] Verify CI verify-links job passes on this branch
- [ ] Confirm actual broken links (e.g. 404) still fail the job
